### PR TITLE
Changing /api route to /equisat.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,7 +12,7 @@ app.use(morgan('dev'));
 app.use(bodyParser.urlencoded({ extended: true })); // for HTML form submits
 app.use(bodyParser.json()); // would be for AJAX requests
 
-app.use('/api', routes);
+app.use('/equisat', routes);
 
 db.sync()
 .then(function (){


### PR DESCRIPTION
Currently, all of our API routes are behind the route '/api' 

I went into the DNS settings and set api.brownspace.org to point to our Google Cloud Platform virtual machine. Having /api at the beginning of all routes seems a bit redundant now.

Also, imagine a world far in the future where we have multiple API's, not just for EQUISat. For future proofing and in an effort to decrease redundancy, I think we should change /api to /equisat (so you'll access the production routes with api.brownspace.org/equisat/whatever)

note: if you're reading this soon after I post it and are wondering why api.brownspace.org doesn't work, DNS still needs to propagate. 